### PR TITLE
Set session data to session object passed via hook

### DIFF
--- a/open-api/system/expressionengine/third_party/open_api/ext.open_api.php
+++ b/open-api/system/expressionengine/third_party/open_api/ext.open_api.php
@@ -46,6 +46,9 @@ class Open_api_ext
 	{	
 		if (isset($this->settings['api_trigger']) AND $this->settings['api_trigger'] AND $this->EE->uri->segment(1) == $this->settings['api_trigger'])
 		{
+			// set session to session passed via hook
+			$this->EE->session = $sess;
+			
 			// load library
 			$this->EE->load->library('open_api_lib');
 


### PR DESCRIPTION
For whatever reason on my setup no session is instantiated when the route_url method is called from the hook. So all calls to session userdata properties work fine once they are set, but all the methods because there is no session class in place.

This is a quick fix for that by setting the EE session to the session object passed via the hook. I'm not sure sure if this is the best way to go about this, but it works on my setup.
